### PR TITLE
Implement product variant update mutation

### DIFF
--- a/tanda_backend/products/graphql/mutations.py
+++ b/tanda_backend/products/graphql/mutations.py
@@ -5,8 +5,15 @@ from graphql.error.graphql_error import GraphQLError
 from graphql_jwt.decorators import login_required
 
 from tanda_backend.merchant.models import Merchant
-from tanda_backend.products.graphql.types import ProductVariantInput, ProductType
+from tanda_backend.products.graphql.types import (
+    ProductVariantInput,
+    ProductType,
+    ProductVariantType,
+)
 from tanda_backend.products.services.create_product import create_product, CreatedProductVariant
+from tanda_backend.products.services.update_product import update_product
+from tanda_backend.products.services.update_product_variant import update_product_variant
+from tanda_backend.products.models import Product, ProductVariant
 
 
 class CreateProduct(graphene.Mutation):
@@ -49,5 +56,76 @@ class CreateProduct(graphene.Mutation):
         return CreateProduct(product=product)
 
 
+class UpdateProduct(graphene.Mutation):
+    class Arguments:
+        product_id = graphene.Int(required=True)
+        title = graphene.String()
+        description = graphene.String()
+        brand = graphene.String()
+
+    product = graphene.Field(ProductType)
+
+    @login_required
+    def mutate(self, info, product_id, title=None, description=None, brand=None):
+        user = info.context.user
+        product = Product.objects.filter(id=product_id, merchant__user=user).first()
+
+        if not product:
+            raise GraphQLError("Product not found.")
+
+        updated_product = update_product(
+            product_id=product_id,
+            title=title,
+            description=description,
+            brand=brand,
+        )
+        return UpdateProduct(product=updated_product)
+
+
+class UpdateProductVariant(graphene.Mutation):
+    class Arguments:
+        variant_id = graphene.Int(required=True)
+        article = graphene.String()
+        cost_price = graphene.Decimal()
+        selling_price = graphene.Decimal()
+        option_value_ids = graphene.List(graphene.Int)
+        image_id = graphene.Int()
+
+    product_variant = graphene.Field(ProductVariantType)
+
+    @login_required
+    def mutate(
+        self,
+        info,
+        variant_id,
+        article=None,
+        cost_price=None,
+        selling_price=None,
+        option_value_ids=None,
+        image_id=None,
+    ):
+        user = info.context.user
+        variant = ProductVariant.objects.filter(
+            id=variant_id,
+            product__merchant__user=user,
+        ).first()
+
+        if not variant:
+            raise GraphQLError("Product variant not found.")
+
+        updated_variant = update_product_variant(
+            variant_id=variant_id,
+            article=article,
+            cost_price=Decimal(str(cost_price)) if cost_price is not None else None,
+            selling_price=Decimal(str(selling_price)) if selling_price is not None else None,
+            option_value_ids=option_value_ids,
+            image_id=image_id,
+        )
+
+        return UpdateProductVariant(product_variant=updated_variant)
+
+
 class Mutation(graphene.ObjectType):
     create_product = CreateProduct.Field()
+    update_product = UpdateProduct.Field()
+    update_product_variant = UpdateProductVariant.Field()

--- a/tanda_backend/products/services/update_product.py
+++ b/tanda_backend/products/services/update_product.py
@@ -1,0 +1,35 @@
+from typing import Optional
+
+from django.utils.text import slugify
+
+from tanda_backend.products.models import Product
+
+
+def update_product(
+    product_id: int,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    brand: Optional[str] = None,
+) -> Product:
+    """Update product fields."""
+    product = Product.objects.get(id=product_id)
+
+    update_fields = []
+
+    if title is not None:
+        product.title = title
+        product.slug = slugify(title)
+        update_fields.extend(["title", "slug"])
+
+    if description is not None:
+        product.description = description
+        update_fields.append("description")
+
+    if brand is not None:
+        product.brand = brand
+        update_fields.append("brand")
+
+    if update_fields:
+        product.save(update_fields=update_fields)
+
+    return product

--- a/tanda_backend/products/services/update_product_variant.py
+++ b/tanda_backend/products/services/update_product_variant.py
@@ -1,0 +1,65 @@
+from decimal import Decimal
+from typing import Optional, Iterable
+from urllib.parse import urlparse
+
+from django.db import transaction
+
+from tanda_backend.products.models import (
+    ProductVariant,
+    VariantOption,
+    OptionValue,
+    Image,
+)
+
+
+def update_product_variant(
+    variant_id: int,
+    article: Optional[str] = None,
+    cost_price: Optional[Decimal] = None,
+    selling_price: Optional[Decimal] = None,
+    option_value_ids: Optional[Iterable[int]] = None,
+    image_id: Optional[int] = None,
+) -> ProductVariant:
+    """Update product variant fields and options."""
+    variant = ProductVariant.objects.select_related("product__merchant").get(id=variant_id)
+
+    update_fields = []
+
+    if article is not None and article != variant.article:
+        exists = ProductVariant.objects.filter(
+            article=article,
+            product__merchant=variant.product.merchant,
+        ).exclude(id=variant.id).exists()
+        if exists:
+            raise ValueError("Article already exists for this merchant.")
+        variant.article = article
+        update_fields.append("article")
+
+    if cost_price is not None:
+        variant.cost_price = cost_price
+        update_fields.append("cost_price")
+
+    if selling_price is not None:
+        variant.selling_price = selling_price
+        update_fields.append("selling_price")
+
+    if image_id is not None:
+        image = Image.objects.get(id=image_id)
+        variant.images = [urlparse(image.file.url).path.lstrip("/")]
+        update_fields.append("images")
+
+    with transaction.atomic():
+        if update_fields:
+            variant.save(update_fields=update_fields)
+
+        if option_value_ids is not None:
+            VariantOption.objects.filter(product_variant=variant).delete()
+            for value_id in option_value_ids:
+                if not OptionValue.objects.filter(id=value_id).exists():
+                    raise ValueError(f"Value option with ID {value_id} does not exist.")
+                VariantOption.objects.create(
+                    product_variant=variant,
+                    option_value_id=value_id,
+                )
+
+    return variant


### PR DESCRIPTION
## Summary
- add a service for updating product variants
- expose `updateProductVariant` GraphQL mutation

## Testing
- `python -m py_compile tanda_backend/products/services/update_product_variant.py`
- `python -m py_compile tanda_backend/products/graphql/mutations.py`


------
https://chatgpt.com/codex/tasks/task_e_684ff49428188320a61676cca4706014