### PR TITLE
Support multi-merchant orders

### DIFF
--- a/tanda_backend/orders/graphql/mutations.py
+++ b/tanda_backend/orders/graphql/mutations.py
@@ -4,7 +4,7 @@ from django.db import transaction
 
 from tanda_backend.orders.graphql.types import OrderType
 from tanda_backend.orders.models import PaymentType, DeliveryType
-from tanda_backend.orders.services import create_order
+from tanda_backend.orders.services import create_orders
 
 
 class VariantInput(graphene.InputObjectType):
@@ -23,7 +23,7 @@ class CreateOrder(graphene.Mutation):
         comments = graphene.String()
         variants = graphene.List(VariantInput, required=True)
 
-    order = graphene.Field(OrderType)
+    orders = graphene.List(OrderType)
 
     @login_required
     @transaction.atomic
@@ -51,7 +51,7 @@ class CreateOrder(graphene.Mutation):
         except ValueError:
             raise Exception("Invalid delivery method")
 
-        order = create_order(
+        orders = create_orders(
             user=user,
             full_name=full_name,
             phone_number=phone_number,
@@ -62,7 +62,7 @@ class CreateOrder(graphene.Mutation):
             comments=comments,
             variants=variants
         )
-        return CreateOrder(order=order)
+        return CreateOrder(orders=orders)
 
 
 class Mutation(graphene.ObjectType):

--- a/tanda_backend/orders/services/__init__.py
+++ b/tanda_backend/orders/services/__init__.py
@@ -1,1 +1,1 @@
-from .create_order import create_order
+from .create_order import create_orders

--- a/tanda_backend/orders/services/create_order.py
+++ b/tanda_backend/orders/services/create_order.py
@@ -1,9 +1,12 @@
+from collections import defaultdict
+from typing import Iterable, List
+
 from tanda_backend.orders.models import PaymentType, DeliveryType, Order, OrderItem
 from tanda_backend.products.models import ProductVariant
 from tanda_backend.users.models import User
 
 
-def create_order(
+def create_orders(
     user: User,
     full_name: str,
     phone_number: str,
@@ -12,42 +15,41 @@ def create_order(
     address: str,
     delivery_type: DeliveryType,
     comments: str,
-    variants,
-):
-    product_variants = []
-    merchant_ids = set()
+    variants: Iterable,
+) -> List[Order]:
+    variant_groups: dict[int, list[tuple[ProductVariant, int]]] = defaultdict(list)
 
     for variant in variants:
         product_variant = ProductVariant.objects.get(id=variant.variant_id)
-        product_variants.append((product_variant, variant.quantity))
+        merchant_id = product_variant.product.merchant_id
+        variant_groups[merchant_id].append((product_variant, variant.quantity))
 
-        if product_variant.product.merchant_id:
-            merchant_ids.add(product_variant.product.merchant_id)
-
-    if len(merchant_ids) > 1:
-        raise ValueError("Cannot create an order with products from different merchants")
-
-    if len(merchant_ids) == 0:
+    if not variant_groups:
         raise ValueError("Cannot create an order with no products")
 
-    order = Order.objects.create(
-        user=user,
-        full_name=full_name,
-        phone_number=phone_number,
-        payment_type=payment_type,
-        city=city,
-        address=address,
-        delivery_type=delivery_type,
-        comments=comments,
-        merchant_id=merchant_ids.pop(),
-    )
+    created_orders: list[Order] = []
 
-    for product_variant, quantity in product_variants:
-        OrderItem.objects.create(
-            order=order,
-            variant=product_variant,
-            quantity=quantity,
-            selling_price=product_variant.selling_price,
+    for merchant_id, items in variant_groups.items():
+        order = Order.objects.create(
+            user=user,
+            full_name=full_name,
+            phone_number=phone_number,
+            payment_type=payment_type,
+            city=city,
+            address=address,
+            delivery_type=delivery_type,
+            comments=comments,
+            merchant_id=merchant_id,
         )
 
-    return order
+        for product_variant, quantity in items:
+            OrderItem.objects.create(
+                order=order,
+                variant=product_variant,
+                quantity=quantity,
+                selling_price=product_variant.selling_price,
+            )
+
+        created_orders.append(order)
+
+    return created_orders

--- a/tanda_backend/orders/tests.py
+++ b/tanda_backend/orders/tests.py
@@ -1,3 +1,59 @@
+from types import SimpleNamespace
+
 from django.test import TestCase
 
-# Create your tests here.
+from tanda_backend.merchant.models import Merchant, Provider
+from tanda_backend.orders.models import DeliveryType, Order, PaymentType
+from tanda_backend.orders.services import create_orders
+from tanda_backend.products.models import Product, ProductVariant
+from tanda_backend.users.models import User
+
+
+class CreateOrdersTestCase(TestCase):
+    def setUp(self) -> None:
+        self.provider = Provider.objects.create(name="Provider")
+        self.user = User.objects.create(username="user", sso_id="1")
+
+    def _create_variant(self, merchant: Merchant, stock_id: str) -> ProductVariant:
+        product = Product.objects.create(
+            title=f"Product {stock_id}",
+            slug=f"product-{stock_id}",
+            images=["img"],
+            stock_id=f"prod-{stock_id}",
+            merchant=merchant,
+            provider=self.provider,
+        )
+        return ProductVariant.objects.create(
+            product=product,
+            stock_id=stock_id,
+            available_quantity=10,
+            selling_price=5,
+        )
+
+    def test_multiple_orders_created_for_different_merchants(self) -> None:
+        merchant1 = Merchant.objects.create(name="M1", provider=self.provider)
+        merchant2 = Merchant.objects.create(name="M2", provider=self.provider)
+
+        v1 = self._create_variant(merchant1, "v1")
+        v2 = self._create_variant(merchant2, "v2")
+
+        variants = [
+            SimpleNamespace(variant_id=v1.id, quantity=1),
+            SimpleNamespace(variant_id=v2.id, quantity=2),
+        ]
+
+        orders = create_orders(
+            user=self.user,
+            full_name="John Doe",
+            phone_number="123", 
+            payment_type=PaymentType.CASH,
+            city="City",
+            address="Address",
+            delivery_type=DeliveryType.SELF_DELIVERY,
+            comments="",
+            variants=variants,
+        )
+
+        self.assertEqual(Order.objects.count(), 2)
+        self.assertEqual(len(orders), 2)
+        self.assertSetEqual({o.merchant_id for o in orders}, {merchant1.id, merchant2.id})


### PR DESCRIPTION
## Summary
- create orders per merchant
- expose `create_orders` helper
- return a list of orders in the mutation
- test creating multiple orders for different merchants

## Testing
- `pytest tanda_backend/orders/tests.py::CreateOrdersTestCase::test_multiple_orders_created_for_different_merchants -q` *(fails: django.db.utils.OperationalError: near "[]": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68677e14816c8320a7ffaad1e3590439